### PR TITLE
Fix a typo on the index page

### DIFF
--- a/source/library/Podcast/Site/Index.hs
+++ b/source/library/Podcast/Site/Index.hs
@@ -29,7 +29,7 @@ body root episodes = Html.node
       "p"
       [("class", "lead")]
       [ Html.text
-          "Haskell Weekly is a podcast covering the Haskell progamming \
+          "Haskell Weekly is a podcast covering the Haskell programming \
           \langauge. Listen to professional software developers discuss using \
           \functional programming to solve real-world business problems. Each \
           \episode uses a conversational two-host format and runs for about \


### PR DESCRIPTION
I happened to notice some typos. 
Also, there's a typo in the GitHub repo description: `s/langauge/language`, which I cannot influence that easily.

Great thing you do, keep up being 🤘! 🎉 