### PR TITLE
Make links clickable in show notes

### DIFF
--- a/podcast.cabal
+++ b/podcast.cabal
@@ -40,6 +40,7 @@ library
     Podcast.Site.Index
     Podcast.Site.Logo
     Podcast.Site.Template
+    Podcast.Type.Article
     Podcast.Type.Bytes
     Podcast.Type.Date
     Podcast.Type.Description

--- a/podcast.cabal
+++ b/podcast.cabal
@@ -45,6 +45,7 @@ library
     Podcast.Type.Description
     Podcast.Type.Episode
     Podcast.Type.Guid
+    Podcast.Type.Media
     Podcast.Type.Number
     Podcast.Type.Route
     Podcast.Type.Seconds

--- a/source/library/Podcast/Episodes.hs
+++ b/source/library/Podcast/Episodes.hs
@@ -169,7 +169,8 @@ episodes =
           "https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
     <*> Date.fromGregorian 2019 3 18
     <*> Description.fromString
-          "Sara Lichtenstein and Taylor Fausak talk about the good and bad of \ \upgrading from Elm 0.18 to 0.19.\n\n\
+          "Sara Lichtenstein and Taylor Fausak talk about the good and bad of \
+          \upgrading from Elm 0.18 to 0.19.\n\n\
           \https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
     <*> Seconds.fromTimestamp 14 59
     <*> Guid.fromString "00900298-5aa6-4301-a207-619d38cdc81a"

--- a/source/library/Podcast/Episodes.hs
+++ b/source/library/Podcast/Episodes.hs
@@ -3,6 +3,7 @@ module Podcast.Episodes
   )
 where
 
+import qualified Podcast.Type.Article as Article
 import qualified Podcast.Type.Bytes as Bytes
 import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
@@ -28,6 +29,7 @@ episodes =
     <*> Number.fromNatural 12
     <*> pure (Bytes.fromNatural 23912963)
     <*> Title.fromString "Formatting code"
+    <*> Article.fromString "https://www.tweag.io/posts/2019-05-27-ormolu.html"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 27
     <*> Description.fromString
@@ -41,6 +43,7 @@ episodes =
     <*> Number.fromNatural 11
     <*> pure (Bytes.fromNatural 27690623)
     <*> Title.fromString "Profiling performance"
+    <*> Article.fromString "https://blog.jez.io/profiling-in-haskell/"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 20
     <*> Description.fromString
@@ -54,6 +57,8 @@ episodes =
     <*> Number.fromNatural 10
     <*> pure (Bytes.fromNatural 23942886)
     <*> Title.fromString "Functional architecture"
+    <*> Article.fromString
+          "https://blog.ploeh.dk/2016/03/18/functional-architecture-is-ports-and-adapters/"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 6
     <*> Description.fromString
@@ -67,6 +72,8 @@ episodes =
     <*> Number.fromNatural 9
     <*> pure (Bytes.fromNatural 31507647)
     <*> Title.fromString "Improving Haskell"
+    <*> Article.fromString
+          "https://medium.com/daml-driven/four-tweaks-to-improve-haskell-b1de9c87f816"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 29
     <*> Description.fromString
@@ -80,6 +87,8 @@ episodes =
     <*> Number.fromNatural 8
     <*> pure (Bytes.fromNatural 20714874)
     <*> Title.fromString "Best practices"
+    <*> Article.fromString
+          "https://medium.com/co-star-engineering/continuous-improvement-with-hlint-code-smells-e490886558a1"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 22
     <*> Description.fromString
@@ -93,6 +102,8 @@ episodes =
     <*> Number.fromNatural 7
     <*> pure (Bytes.fromNatural 25296111)
     <*> Title.fromString "Parser combinators"
+    <*> Article.fromString
+          "https://williamyaoh.com/posts/2019-04-11-cheatsheet-to-regexes-in-haskell.html"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 15
     <*> Description.fromString
@@ -106,6 +117,8 @@ episodes =
     <*> Number.fromNatural 6
     <*> pure (Bytes.fromNatural 26845627)
     <*> Title.fromString "Fast feedback"
+    <*> Article.fromString
+          "https://functor.tokyo/blog/2019-04-07-ghcid-for-web-app-dev"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 8
     <*> Description.fromString
@@ -119,6 +132,8 @@ episodes =
     <*> Number.fromNatural 5
     <*> pure (Bytes.fromNatural 21977225)
     <*> Title.fromString "Build tools"
+    <*> Article.fromString
+          "https://sakshamsharma.com/2018/03/haskell-proj-struct/"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 1
     <*> Description.fromString
@@ -132,6 +147,8 @@ episodes =
     <*> Number.fromNatural 4
     <*> pure (Bytes.fromNatural 23002958)
     <*> Title.fromString "Boolean blindness"
+    <*> Article.fromString
+          "https://runtimeverification.com/blog/code-smell-boolean-blindness/"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 25
     <*> Description.fromString
@@ -145,6 +162,8 @@ episodes =
     <*> Number.fromNatural 3
     <*> pure (Bytes.fromNatural 34265398)
     <*> Title.fromString "Frontend languages"
+    <*> Article.fromString
+          "https://www.parsonsmatt.org/2015/10/03/elm_vs_purescript.html"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 18
     <*> Description.fromString
@@ -157,6 +176,8 @@ episodes =
     <*> Number.fromNatural 2
     <*> pure (Bytes.fromNatural 21580339)
     <*> Title.fromString "Upgrading Elm"
+    <*> Article.fromString
+          "https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 11
     <*> Description.fromString
@@ -170,4 +191,5 @@ episodes =
     <*> Number.fromNatural 1
     <*> pure (Bytes.fromNatural 13999481)
     <*> Title.fromString "Handling exceptions"
+    <*> Article.fromString "https://markkarpov.com/tutorial/exceptions.html"
   ]

--- a/source/library/Podcast/Episodes.hs
+++ b/source/library/Podcast/Episodes.hs
@@ -11,7 +11,7 @@ import qualified Podcast.Type.Guid as Guid
 import qualified Podcast.Type.Number as Number
 import qualified Podcast.Type.Seconds as Seconds
 import qualified Podcast.Type.Title as Title
-import qualified Podcast.Type.Url as Url
+import qualified Podcast.Type.Media as Media
 
 episodes :: [Either String Episode.Episode]
 episodes =
@@ -26,7 +26,7 @@ episodes =
     <*> Number.fromNatural 12
     <*> pure (Bytes.fromNatural 23912963)
     <*> Title.fromString "Formatting code"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-06-03-episode-12.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 27
@@ -39,7 +39,7 @@ episodes =
     <*> Number.fromNatural 11
     <*> pure (Bytes.fromNatural 27690623)
     <*> Title.fromString "Profiling performance"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-27-episode-11.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 20
@@ -52,7 +52,7 @@ episodes =
     <*> Number.fromNatural 10
     <*> pure (Bytes.fromNatural 23942886)
     <*> Title.fromString "Functional architecture"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-20-episode-10.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 6
@@ -65,7 +65,7 @@ episodes =
     <*> Number.fromNatural 9
     <*> pure (Bytes.fromNatural 31507647)
     <*> Title.fromString "Improving Haskell"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-06-episode-9.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 29
@@ -78,7 +78,7 @@ episodes =
     <*> Number.fromNatural 8
     <*> pure (Bytes.fromNatural 20714874)
     <*> Title.fromString "Best practices"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-29-episode-8.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 22
@@ -91,7 +91,7 @@ episodes =
     <*> Number.fromNatural 7
     <*> pure (Bytes.fromNatural 25296111)
     <*> Title.fromString "Parser combinators"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-22-episode-7.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 15
@@ -104,7 +104,7 @@ episodes =
     <*> Number.fromNatural 6
     <*> pure (Bytes.fromNatural 26845627)
     <*> Title.fromString "Fast feedback"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-15-episode-6.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 8
@@ -117,7 +117,7 @@ episodes =
     <*> Number.fromNatural 5
     <*> pure (Bytes.fromNatural 21977225)
     <*> Title.fromString "Build tools"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-08-episode-5.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 1
@@ -130,7 +130,7 @@ episodes =
     <*> Number.fromNatural 4
     <*> pure (Bytes.fromNatural 23002958)
     <*> Title.fromString "Boolean blindness"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-01-episode-4.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 25
@@ -143,7 +143,7 @@ episodes =
     <*> Number.fromNatural 3
     <*> pure (Bytes.fromNatural 34265398)
     <*> Title.fromString "Frontend languages"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-25-episode-3.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 18
@@ -155,7 +155,7 @@ episodes =
     <*> Number.fromNatural 2
     <*> pure (Bytes.fromNatural 21580339)
     <*> Title.fromString "Upgrading Elm"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-18-episode-2.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 11
@@ -168,6 +168,6 @@ episodes =
     <*> Number.fromNatural 1
     <*> pure (Bytes.fromNatural 13999481)
     <*> Title.fromString "Handling exceptions"
-    <*> Url.fromString
+    <*> Media.fromString
           "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-11-episode-1.mp3"
   ]

--- a/source/library/Podcast/Episodes.hs
+++ b/source/library/Podcast/Episodes.hs
@@ -17,7 +17,8 @@ import qualified Podcast.Type.Title as Title
 episodes :: [Either String Episode.Episode]
 episodes =
   [ Episode.Episode
-    <$> Date.fromGregorian 2019 6 3
+    <$> Article.fromString "https://www.tweag.io/posts/2019-05-27-ormolu.html"
+    <*> Date.fromGregorian 2019 6 3
     <*> Description.fromString
           "Dustin Segers and Cody Goodman talk about formatting Haskell \
           \source code with automated tools like Ormolu.\n\n\
@@ -29,9 +30,9 @@ episodes =
     <*> Number.fromNatural 12
     <*> pure (Bytes.fromNatural 23912963)
     <*> Title.fromString "Formatting code"
-    <*> Article.fromString "https://www.tweag.io/posts/2019-05-27-ormolu.html"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 5 27
+    <$> Article.fromString "https://blog.jez.io/profiling-in-haskell/"
+    <*> Date.fromGregorian 2019 5 27
     <*> Description.fromString
           "Sara Lichtenstein and Taylor Fausak talk about improving the \
           \performance of Haskell programs by profiling them.\n\n\
@@ -43,9 +44,10 @@ episodes =
     <*> Number.fromNatural 11
     <*> pure (Bytes.fromNatural 27690623)
     <*> Title.fromString "Profiling performance"
-    <*> Article.fromString "https://blog.jez.io/profiling-in-haskell/"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 5 20
+    <$> Article.fromString
+          "https://blog.ploeh.dk/2016/03/18/functional-architecture-is-ports-and-adapters/"
+    <*> Date.fromGregorian 2019 5 20
     <*> Description.fromString
           "Cameron Gera and Taylor Fausak talk about how Haskell encourages \
           \you to use the ports and adapters architecture.\n\n\
@@ -57,10 +59,10 @@ episodes =
     <*> Number.fromNatural 10
     <*> pure (Bytes.fromNatural 23942886)
     <*> Title.fromString "Functional architecture"
-    <*> Article.fromString
-          "https://blog.ploeh.dk/2016/03/18/functional-architecture-is-ports-and-adapters/"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 5 6
+    <$> Article.fromString
+          "https://medium.com/daml-driven/four-tweaks-to-improve-haskell-b1de9c87f816"
+    <*> Date.fromGregorian 2019 5 6
     <*> Description.fromString
           "Jason Fry and Cameron Gera talk about four small ways to improve \
           \Haskell as a language.\n\n\
@@ -72,10 +74,10 @@ episodes =
     <*> Number.fromNatural 9
     <*> pure (Bytes.fromNatural 31507647)
     <*> Title.fromString "Improving Haskell"
-    <*> Article.fromString
-          "https://medium.com/daml-driven/four-tweaks-to-improve-haskell-b1de9c87f816"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 4 29
+    <$> Article.fromString
+          "https://medium.com/co-star-engineering/continuous-improvement-with-hlint-code-smells-e490886558a1"
+    <*> Date.fromGregorian 2019 4 29
     <*> Description.fromString
           "Cameron Gera and Cody Goodman talk about enforcing best practices \
           \with HLint and refactoring.\n\n\
@@ -87,10 +89,10 @@ episodes =
     <*> Number.fromNatural 8
     <*> pure (Bytes.fromNatural 20714874)
     <*> Title.fromString "Best practices"
-    <*> Article.fromString
-          "https://medium.com/co-star-engineering/continuous-improvement-with-hlint-code-smells-e490886558a1"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 4 22
+    <$> Article.fromString
+          "https://williamyaoh.com/posts/2019-04-11-cheatsheet-to-regexes-in-haskell.html"
+    <*> Date.fromGregorian 2019 4 22
     <*> Description.fromString
           "Cameron Gera and Taylor Fausak talk about how regular expressions \
           \compare to parser combinators in Haskell.\n\n\
@@ -102,10 +104,10 @@ episodes =
     <*> Number.fromNatural 7
     <*> pure (Bytes.fromNatural 25296111)
     <*> Title.fromString "Parser combinators"
-    <*> Article.fromString
-          "https://williamyaoh.com/posts/2019-04-11-cheatsheet-to-regexes-in-haskell.html"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 4 15
+    <$> Article.fromString
+          "https://functor.tokyo/blog/2019-04-07-ghcid-for-web-app-dev"
+    <*> Date.fromGregorian 2019 4 15
     <*> Description.fromString
           "Jason Fry and Taylor Fausak talk about getting fast feedback when \
           \developing Haskell by using ghcid.\n\n\
@@ -117,10 +119,10 @@ episodes =
     <*> Number.fromNatural 6
     <*> pure (Bytes.fromNatural 26845627)
     <*> Title.fromString "Fast feedback"
-    <*> Article.fromString
-          "https://functor.tokyo/blog/2019-04-07-ghcid-for-web-app-dev"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 4 8
+    <$> Article.fromString
+          "https://sakshamsharma.com/2018/03/haskell-proj-struct/"
+    <*> Date.fromGregorian 2019 4 8
     <*> Description.fromString
           "Cameron Gera and Taylor Fausak talk about build tools in Haskell, \
           \including Stack and Cabal.\n\n\
@@ -132,10 +134,10 @@ episodes =
     <*> Number.fromNatural 5
     <*> pure (Bytes.fromNatural 21977225)
     <*> Title.fromString "Build tools"
-    <*> Article.fromString
-          "https://sakshamsharma.com/2018/03/haskell-proj-struct/"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 4 1
+    <$> Article.fromString
+          "https://runtimeverification.com/blog/code-smell-boolean-blindness/"
+    <*> Date.fromGregorian 2019 4 1
     <*> Description.fromString
           "Dustin Segers and Taylor Fausak talk about avoiding boolean \
           \blindness by using custom types.\n\n\
@@ -147,10 +149,10 @@ episodes =
     <*> Number.fromNatural 4
     <*> pure (Bytes.fromNatural 23002958)
     <*> Title.fromString "Boolean blindness"
-    <*> Article.fromString
-          "https://runtimeverification.com/blog/code-smell-boolean-blindness/"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 3 25
+    <$> Article.fromString
+          "https://www.parsonsmatt.org/2015/10/03/elm_vs_purescript.html"
+    <*> Date.fromGregorian 2019 3 25
     <*> Description.fromString
           "Jason Fry and Taylor Fausak compare frontend and backend \
           \languages, including PureScript and Elm.\n\n\
@@ -162,10 +164,10 @@ episodes =
     <*> Number.fromNatural 3
     <*> pure (Bytes.fromNatural 34265398)
     <*> Title.fromString "Frontend languages"
-    <*> Article.fromString
-          "https://www.parsonsmatt.org/2015/10/03/elm_vs_purescript.html"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 3 18
+    <$> Article.fromString
+          "https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
+    <*> Date.fromGregorian 2019 3 18
     <*> Description.fromString
           "Sara Lichtenstein and Taylor Fausak talk about the good and bad of \ \upgrading from Elm 0.18 to 0.19.\n\n\
           \https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
@@ -176,10 +178,9 @@ episodes =
     <*> Number.fromNatural 2
     <*> pure (Bytes.fromNatural 21580339)
     <*> Title.fromString "Upgrading Elm"
-    <*> Article.fromString
-          "https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
   , Episode.Episode
-    <$> Date.fromGregorian 2019 3 11
+    <$> Article.fromString "https://markkarpov.com/tutorial/exceptions.html"
+    <*> Date.fromGregorian 2019 3 11
     <*> Description.fromString
           "Cody Goodman and Taylor Fausak talk about handling errors in \
           \Haskell by using exceptions.\n\n\
@@ -191,5 +192,4 @@ episodes =
     <*> Number.fromNatural 1
     <*> pure (Bytes.fromNatural 13999481)
     <*> Title.fromString "Handling exceptions"
-    <*> Article.fromString "https://markkarpov.com/tutorial/exceptions.html"
   ]

--- a/source/library/Podcast/Episodes.hs
+++ b/source/library/Podcast/Episodes.hs
@@ -8,10 +8,10 @@ import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
 import qualified Podcast.Type.Episode as Episode
 import qualified Podcast.Type.Guid as Guid
+import qualified Podcast.Type.Media as Media
 import qualified Podcast.Type.Number as Number
 import qualified Podcast.Type.Seconds as Seconds
 import qualified Podcast.Type.Title as Title
-import qualified Podcast.Type.Media as Media
 
 episodes :: [Either String Episode.Episode]
 episodes =
@@ -23,11 +23,11 @@ episodes =
           \https://www.tweag.io/posts/2019-05-27-ormolu.html"
     <*> Seconds.fromTimestamp 16 37
     <*> Guid.fromString "f166f89f-1a16-49f1-915a-d54505c301a0"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-06-03-episode-12.mp3"
     <*> Number.fromNatural 12
     <*> pure (Bytes.fromNatural 23912963)
     <*> Title.fromString "Formatting code"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-06-03-episode-12.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 27
     <*> Description.fromString
@@ -36,11 +36,11 @@ episodes =
           \https://blog.jez.io/profiling-in-haskell/"
     <*> Seconds.fromTimestamp 19 12
     <*> Guid.fromString "3ec1dc79-7a9c-46c3-b919-61471e876708"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-27-episode-11.mp3"
     <*> Number.fromNatural 11
     <*> pure (Bytes.fromNatural 27690623)
     <*> Title.fromString "Profiling performance"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-27-episode-11.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 20
     <*> Description.fromString
@@ -49,11 +49,11 @@ episodes =
           \https://blog.ploeh.dk/2016/03/18/functional-architecture-is-ports-and-adapters/"
     <*> Seconds.fromTimestamp 16 37
     <*> Guid.fromString "32fd3459-b349-4c99-9150-5073fedab6bf"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-20-episode-10.mp3"
     <*> Number.fromNatural 10
     <*> pure (Bytes.fromNatural 23942886)
     <*> Title.fromString "Functional architecture"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-20-episode-10.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 5 6
     <*> Description.fromString
@@ -62,11 +62,11 @@ episodes =
           \https://medium.com/daml-driven/four-tweaks-to-improve-haskell-b1de9c87f816"
     <*> Seconds.fromTimestamp 21 52
     <*> Guid.fromString "de704aad-e6a1-41a6-976f-bd3f2ef34ad2"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-06-episode-9.mp3"
     <*> Number.fromNatural 9
     <*> pure (Bytes.fromNatural 31507647)
     <*> Title.fromString "Improving Haskell"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-05-06-episode-9.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 29
     <*> Description.fromString
@@ -75,11 +75,11 @@ episodes =
           \https://medium.com/co-star-engineering/continuous-improvement-with-hlint-code-smells-e490886558a1"
     <*> Seconds.fromTimestamp 14 20
     <*> Guid.fromString "53bbcaeb-6e6f-4e1f-9806-f24032ac7a9f"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-29-episode-8.mp3"
     <*> Number.fromNatural 8
     <*> pure (Bytes.fromNatural 20714874)
     <*> Title.fromString "Best practices"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-29-episode-8.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 22
     <*> Description.fromString
@@ -88,11 +88,11 @@ episodes =
           \https://williamyaoh.com/posts/2019-04-11-cheatsheet-to-regexes-in-haskell.html"
     <*> Seconds.fromTimestamp 17 29
     <*> Guid.fromString "287a197e-e9fd-47b6-9506-2f39be002af7"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-22-episode-7.mp3"
     <*> Number.fromNatural 7
     <*> pure (Bytes.fromNatural 25296111)
     <*> Title.fromString "Parser combinators"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-22-episode-7.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 15
     <*> Description.fromString
@@ -101,11 +101,11 @@ episodes =
           \https://functor.tokyo/blog/2019-04-07-ghcid-for-web-app-dev"
     <*> Seconds.fromTimestamp 18 38
     <*> Guid.fromString "7ed15199-bcd3-461e-af62-d504ae8a4a01"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-15-episode-6.mp3"
     <*> Number.fromNatural 6
     <*> pure (Bytes.fromNatural 26845627)
     <*> Title.fromString "Fast feedback"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-15-episode-6.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 8
     <*> Description.fromString
@@ -114,11 +114,11 @@ episodes =
           \https://sakshamsharma.com/2018/03/haskell-proj-struct/"
     <*> Seconds.fromTimestamp 15 15
     <*> Guid.fromString "25b43cdb-e278-42da-97dc-3c6d353ec8c8"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-08-episode-5.mp3"
     <*> Number.fromNatural 5
     <*> pure (Bytes.fromNatural 21977225)
     <*> Title.fromString "Build tools"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-08-episode-5.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 4 1
     <*> Description.fromString
@@ -127,11 +127,11 @@ episodes =
           \https://runtimeverification.com/blog/code-smell-boolean-blindness/"
     <*> Seconds.fromTimestamp 15 57
     <*> Guid.fromString "aea8101c-b126-4cb5-be14-00200d3f6c27"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-01-episode-4.mp3"
     <*> Number.fromNatural 4
     <*> pure (Bytes.fromNatural 23002958)
     <*> Title.fromString "Boolean blindness"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-04-01-episode-4.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 25
     <*> Description.fromString
@@ -140,11 +140,11 @@ episodes =
           \https://www.parsonsmatt.org/2015/10/03/elm_vs_purescript.html"
     <*> Seconds.fromTimestamp 23 47
     <*> Guid.fromString "069964f7-2457-479f-8bab-9cb4f3abec9c"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-25-episode-3.mp3"
     <*> Number.fromNatural 3
     <*> pure (Bytes.fromNatural 34265398)
     <*> Title.fromString "Frontend languages"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-25-episode-3.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 18
     <*> Description.fromString
@@ -152,11 +152,11 @@ episodes =
           \https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
     <*> Seconds.fromTimestamp 14 59
     <*> Guid.fromString "00900298-5aa6-4301-a207-619d38cdc81a"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-18-episode-2.mp3"
     <*> Number.fromNatural 2
     <*> pure (Bytes.fromNatural 21580339)
     <*> Title.fromString "Upgrading Elm"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-18-episode-2.mp3"
   , Episode.Episode
     <$> Date.fromGregorian 2019 3 11
     <*> Description.fromString
@@ -165,9 +165,9 @@ episodes =
           \https://markkarpov.com/tutorial/exceptions.html"
     <*> Seconds.fromTimestamp 9 43
     <*> Guid.fromString "6fe12dba-e0c3-4af5-b9fc-844bc2396ae7"
+    <*> Media.fromString
+          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-11-episode-1.mp3"
     <*> Number.fromNatural 1
     <*> pure (Bytes.fromNatural 13999481)
     <*> Title.fromString "Handling exceptions"
-    <*> Media.fromString
-          "https://haskell-weekly-podcast.nyc3.cdn.digitaloceanspaces.com/2019-03-11-episode-1.mp3"
   ]

--- a/source/library/Podcast/Episodes.hs
+++ b/source/library/Podcast/Episodes.hs
@@ -21,8 +21,7 @@ episodes =
     <*> Date.fromGregorian 2019 6 3
     <*> Description.fromString
           "Dustin Segers and Cody Goodman talk about formatting Haskell \
-          \source code with automated tools like Ormolu.\n\n\
-          \https://www.tweag.io/posts/2019-05-27-ormolu.html"
+          \source code with automated tools like Ormolu."
     <*> Seconds.fromTimestamp 16 37
     <*> Guid.fromString "f166f89f-1a16-49f1-915a-d54505c301a0"
     <*> Media.fromString
@@ -35,8 +34,7 @@ episodes =
     <*> Date.fromGregorian 2019 5 27
     <*> Description.fromString
           "Sara Lichtenstein and Taylor Fausak talk about improving the \
-          \performance of Haskell programs by profiling them.\n\n\
-          \https://blog.jez.io/profiling-in-haskell/"
+          \performance of Haskell programs by profiling them."
     <*> Seconds.fromTimestamp 19 12
     <*> Guid.fromString "3ec1dc79-7a9c-46c3-b919-61471e876708"
     <*> Media.fromString
@@ -50,8 +48,7 @@ episodes =
     <*> Date.fromGregorian 2019 5 20
     <*> Description.fromString
           "Cameron Gera and Taylor Fausak talk about how Haskell encourages \
-          \you to use the ports and adapters architecture.\n\n\
-          \https://blog.ploeh.dk/2016/03/18/functional-architecture-is-ports-and-adapters/"
+          \you to use the ports and adapters architecture."
     <*> Seconds.fromTimestamp 16 37
     <*> Guid.fromString "32fd3459-b349-4c99-9150-5073fedab6bf"
     <*> Media.fromString
@@ -65,8 +62,7 @@ episodes =
     <*> Date.fromGregorian 2019 5 6
     <*> Description.fromString
           "Jason Fry and Cameron Gera talk about four small ways to improve \
-          \Haskell as a language.\n\n\
-          \https://medium.com/daml-driven/four-tweaks-to-improve-haskell-b1de9c87f816"
+          \Haskell as a language."
     <*> Seconds.fromTimestamp 21 52
     <*> Guid.fromString "de704aad-e6a1-41a6-976f-bd3f2ef34ad2"
     <*> Media.fromString
@@ -80,8 +76,7 @@ episodes =
     <*> Date.fromGregorian 2019 4 29
     <*> Description.fromString
           "Cameron Gera and Cody Goodman talk about enforcing best practices \
-          \with HLint and refactoring.\n\n\
-          \https://medium.com/co-star-engineering/continuous-improvement-with-hlint-code-smells-e490886558a1"
+          \with HLint and refactoring."
     <*> Seconds.fromTimestamp 14 20
     <*> Guid.fromString "53bbcaeb-6e6f-4e1f-9806-f24032ac7a9f"
     <*> Media.fromString
@@ -95,8 +90,7 @@ episodes =
     <*> Date.fromGregorian 2019 4 22
     <*> Description.fromString
           "Cameron Gera and Taylor Fausak talk about how regular expressions \
-          \compare to parser combinators in Haskell.\n\n\
-          \https://williamyaoh.com/posts/2019-04-11-cheatsheet-to-regexes-in-haskell.html"
+          \compare to parser combinators in Haskell."
     <*> Seconds.fromTimestamp 17 29
     <*> Guid.fromString "287a197e-e9fd-47b6-9506-2f39be002af7"
     <*> Media.fromString
@@ -110,8 +104,7 @@ episodes =
     <*> Date.fromGregorian 2019 4 15
     <*> Description.fromString
           "Jason Fry and Taylor Fausak talk about getting fast feedback when \
-          \developing Haskell by using ghcid.\n\n\
-          \https://functor.tokyo/blog/2019-04-07-ghcid-for-web-app-dev"
+          \developing Haskell by using ghcid."
     <*> Seconds.fromTimestamp 18 38
     <*> Guid.fromString "7ed15199-bcd3-461e-af62-d504ae8a4a01"
     <*> Media.fromString
@@ -125,8 +118,7 @@ episodes =
     <*> Date.fromGregorian 2019 4 8
     <*> Description.fromString
           "Cameron Gera and Taylor Fausak talk about build tools in Haskell, \
-          \including Stack and Cabal.\n\n\
-          \https://sakshamsharma.com/2018/03/haskell-proj-struct/"
+          \including Stack and Cabal."
     <*> Seconds.fromTimestamp 15 15
     <*> Guid.fromString "25b43cdb-e278-42da-97dc-3c6d353ec8c8"
     <*> Media.fromString
@@ -140,8 +132,7 @@ episodes =
     <*> Date.fromGregorian 2019 4 1
     <*> Description.fromString
           "Dustin Segers and Taylor Fausak talk about avoiding boolean \
-          \blindness by using custom types.\n\n\
-          \https://runtimeverification.com/blog/code-smell-boolean-blindness/"
+          \blindness by using custom types."
     <*> Seconds.fromTimestamp 15 57
     <*> Guid.fromString "aea8101c-b126-4cb5-be14-00200d3f6c27"
     <*> Media.fromString
@@ -155,8 +146,7 @@ episodes =
     <*> Date.fromGregorian 2019 3 25
     <*> Description.fromString
           "Jason Fry and Taylor Fausak compare frontend and backend \
-          \languages, including PureScript and Elm.\n\n\
-          \https://www.parsonsmatt.org/2015/10/03/elm_vs_purescript.html"
+          \languages, including PureScript and Elm."
     <*> Seconds.fromTimestamp 23 47
     <*> Guid.fromString "069964f7-2457-479f-8bab-9cb4f3abec9c"
     <*> Media.fromString
@@ -170,8 +160,7 @@ episodes =
     <*> Date.fromGregorian 2019 3 18
     <*> Description.fromString
           "Sara Lichtenstein and Taylor Fausak talk about the good and bad of \
-          \upgrading from Elm 0.18 to 0.19.\n\n\
-          \https://engineering.itpro.tv/2019/03/01/upgrading-elm-to-v19/"
+          \upgrading from Elm 0.18 to 0.19."
     <*> Seconds.fromTimestamp 14 59
     <*> Guid.fromString "00900298-5aa6-4301-a207-619d38cdc81a"
     <*> Media.fromString
@@ -184,8 +173,7 @@ episodes =
     <*> Date.fromGregorian 2019 3 11
     <*> Description.fromString
           "Cody Goodman and Taylor Fausak talk about handling errors in \
-          \Haskell by using exceptions.\n\n\
-          \https://markkarpov.com/tutorial/exceptions.html"
+          \Haskell by using exceptions."
     <*> Seconds.fromTimestamp 9 43
     <*> Guid.fromString "6fe12dba-e0c3-4af5-b9fc-844bc2396ae7"
     <*> Media.fromString

--- a/source/library/Podcast/Site/Episode.hs
+++ b/source/library/Podcast/Site/Episode.hs
@@ -8,6 +8,7 @@ import qualified Podcast.Site.Template as Template
 import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
 import qualified Podcast.Type.Episode as Episode
+import qualified Podcast.Type.Media as Media
 import qualified Podcast.Type.Number as Number
 import qualified Podcast.Type.Title as Title
 import qualified Podcast.Type.Url as Url
@@ -44,7 +45,7 @@ html root episode = Template.html
             [ ("class", "d-block w-100")
             , ("controls", "controls")
             , ("preload", "metadata")
-            , ("src", Url.toString (Episode.url episode))
+            , ("src", Media.toString (Episode.url episode))
             ]
             [Html.text ""]
         ]

--- a/source/library/Podcast/Site/Episode.hs
+++ b/source/library/Podcast/Site/Episode.hs
@@ -5,6 +5,7 @@ where
 
 import qualified Podcast.Html as Html
 import qualified Podcast.Site.Template as Template
+import qualified Podcast.Type.Article as Article
 import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
 import qualified Podcast.Type.Episode as Episode
@@ -58,8 +59,20 @@ html root episode = Template.html
             [ Html.node
                 "div"
                 [("class", "card-body"), ("style", "white-space: pre-wrap;")]
-                [ Html.text
-                    (Description.toString (Episode.description episode))
+                [ Html.node
+                  "p"
+                  []
+                  [ Html.text
+                      (Description.toString (Episode.description episode))
+                  ]
+                , Html.node
+                  "p"
+                  []
+                  [ Html.node
+                      "a"
+                      [("href", Article.toString (Episode.article episode))]
+                      [Html.text (Article.toString (Episode.article episode))]
+                  ]
                 ]
             ]
         ]

--- a/source/library/Podcast/Site/Episode.hs
+++ b/source/library/Podcast/Site/Episode.hs
@@ -45,7 +45,7 @@ html root episode = Template.html
             [ ("class", "d-block w-100")
             , ("controls", "controls")
             , ("preload", "metadata")
-            , ("src", Media.toString (Episode.url episode))
+            , ("src", Media.toString (Episode.media episode))
             ]
             [Html.text ""]
         ]

--- a/source/library/Podcast/Site/Feed.hs
+++ b/source/library/Podcast/Site/Feed.hs
@@ -3,6 +3,7 @@ module Podcast.Site.Feed
   )
 where
 
+import qualified Podcast.Type.Article as Article
 import qualified Podcast.Type.Bytes as Bytes
 import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
@@ -15,6 +16,7 @@ import qualified Podcast.Type.Seconds as Seconds
 import qualified Podcast.Type.Title as Title
 import qualified Podcast.Type.Url as Url
 import qualified Podcast.Xml as Xml
+import qualified Podcast.Xml.Render as Render
 
 rss :: Url.Url -> [Episode.Episode] -> Xml.Element
 rss root episodes = Xml.element
@@ -127,7 +129,23 @@ itemDescription :: Episode.Episode -> Xml.Node
 itemDescription episode = Xml.node
   "description"
   []
-  [Xml.text (Description.toString (Episode.description episode))]
+  [ Xml.text
+      (Render.nodes
+        [ Xml.node
+          "p"
+          []
+          [Xml.text (Description.toString (Episode.description episode))]
+        , Xml.node
+          "p"
+          []
+          [ Xml.node
+              "a"
+              [("href", Article.toString (Episode.article episode))]
+              [Xml.text (Article.toString (Episode.article episode))]
+          ]
+        ]
+      )
+  ]
 
 itemDuration :: Episode.Episode -> Xml.Node
 itemDuration episode = Xml.node

--- a/source/library/Podcast/Site/Feed.hs
+++ b/source/library/Podcast/Site/Feed.hs
@@ -192,7 +192,5 @@ itemPubDate episode =
   Xml.node "pubDate" [] [Xml.text (Date.toRfc822 (Episode.date episode))]
 
 itemTitle :: Episode.Episode -> Xml.Node
-itemTitle episode = Xml.node
-  "title"
-  []
-  [Xml.text (Title.toString (Episode.title episode))]
+itemTitle episode =
+  Xml.node "title" [] [Xml.text (Title.toString (Episode.title episode))]

--- a/source/library/Podcast/Site/Feed.hs
+++ b/source/library/Podcast/Site/Feed.hs
@@ -8,6 +8,7 @@ import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
 import qualified Podcast.Type.Episode as Episode
 import qualified Podcast.Type.Guid as Guid
+import qualified Podcast.Type.Media as Media
 import qualified Podcast.Type.Number as Number
 import qualified Podcast.Type.Route as Route
 import qualified Podcast.Type.Seconds as Seconds
@@ -139,7 +140,7 @@ itemEnclosure episode = Xml.node
   "enclosure"
   [ ("type", "audio/mpeg")
   , ("length", Bytes.toString (Episode.size episode))
-  , ("url", Url.toString (Episode.url episode))
+  , ("url", Media.toString (Episode.url episode))
   ]
   []
 

--- a/source/library/Podcast/Site/Feed.hs
+++ b/source/library/Podcast/Site/Feed.hs
@@ -140,7 +140,7 @@ itemEnclosure episode = Xml.node
   "enclosure"
   [ ("type", "audio/mpeg")
   , ("length", Bytes.toString (Episode.size episode))
-  , ("url", Media.toString (Episode.url episode))
+  , ("url", Media.toString (Episode.media episode))
   ]
   []
 

--- a/source/library/Podcast/Site/Index.hs
+++ b/source/library/Podcast/Site/Index.hs
@@ -70,15 +70,7 @@ item root episode = Html.node
           , Html.node
             "p"
             [("class", "card-text")]
-            [ Html.text
-                (concat
-                  (take
-                    1
-                    (lines (Description.toString (Episode.description episode))
-                    )
-                  )
-                )
-            ]
+            [Html.text (Description.toString (Episode.description episode))]
           , Html.node
             "a"
             [ ("class", "card-link")

--- a/source/library/Podcast/Site/Template.hs
+++ b/source/library/Podcast/Site/Template.hs
@@ -83,7 +83,10 @@ body root content = Html.node
             , Html.text ". You can subscribe to the "
             , Html.node
               "a"
-              [("href", Url.toString (Url.combine root (Route.toUrl Route.Feed)))]
+              [ ( "href"
+                , Url.toString (Url.combine root (Route.toUrl Route.Feed))
+                )
+              ]
               [Html.text "RSS feed"]
             , Html.text "."
             ]

--- a/source/library/Podcast/Type/Article.hs
+++ b/source/library/Podcast/Type/Article.hs
@@ -1,0 +1,18 @@
+module Podcast.Type.Article
+  ( Article
+  , fromString
+  , toString
+  )
+where
+
+import qualified Podcast.Type.Url as Url
+
+newtype Article
+  = Article Url.Url
+  deriving (Eq, Ord, Show)
+
+fromString :: String -> Either String Article
+fromString string = fmap Article (Url.fromString string)
+
+toString :: Article -> String
+toString (Article url) = Url.toString url

--- a/source/library/Podcast/Type/Episode.hs
+++ b/source/library/Podcast/Type/Episode.hs
@@ -7,18 +7,18 @@ import qualified Podcast.Type.Bytes as Bytes
 import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
 import qualified Podcast.Type.Guid as Guid
+import qualified Podcast.Type.Media as Media
 import qualified Podcast.Type.Number as Number
 import qualified Podcast.Type.Seconds as Seconds
 import qualified Podcast.Type.Title as Title
-import qualified Podcast.Type.Media as Media
 
 data Episode = Episode
   { date :: Date.Date
   , description :: Description.Description
   , duration :: Seconds.Seconds
   , guid :: Guid.Guid
+  , media :: Media.Media
   , number :: Number.Number
   , size :: Bytes.Bytes
   , title :: Title.Title
-  , media :: Media.Media
   } deriving (Eq, Ord, Show)

--- a/source/library/Podcast/Type/Episode.hs
+++ b/source/library/Podcast/Type/Episode.hs
@@ -20,5 +20,5 @@ data Episode = Episode
   , number :: Number.Number
   , size :: Bytes.Bytes
   , title :: Title.Title
-  , url :: Media.Media
+  , media :: Media.Media
   } deriving (Eq, Ord, Show)

--- a/source/library/Podcast/Type/Episode.hs
+++ b/source/library/Podcast/Type/Episode.hs
@@ -3,6 +3,7 @@ module Podcast.Type.Episode
   )
 where
 
+import qualified Podcast.Type.Article as Article
 import qualified Podcast.Type.Bytes as Bytes
 import qualified Podcast.Type.Date as Date
 import qualified Podcast.Type.Description as Description
@@ -21,4 +22,5 @@ data Episode = Episode
   , number :: Number.Number
   , size :: Bytes.Bytes
   , title :: Title.Title
+  , article :: Article.Article
   } deriving (Eq, Ord, Show)

--- a/source/library/Podcast/Type/Episode.hs
+++ b/source/library/Podcast/Type/Episode.hs
@@ -10,7 +10,7 @@ import qualified Podcast.Type.Guid as Guid
 import qualified Podcast.Type.Number as Number
 import qualified Podcast.Type.Seconds as Seconds
 import qualified Podcast.Type.Title as Title
-import qualified Podcast.Type.Url as Url
+import qualified Podcast.Type.Media as Media
 
 data Episode = Episode
   { date :: Date.Date
@@ -20,5 +20,5 @@ data Episode = Episode
   , number :: Number.Number
   , size :: Bytes.Bytes
   , title :: Title.Title
-  , url :: Url.Url
+  , url :: Media.Media
   } deriving (Eq, Ord, Show)

--- a/source/library/Podcast/Type/Episode.hs
+++ b/source/library/Podcast/Type/Episode.hs
@@ -14,7 +14,8 @@ import qualified Podcast.Type.Seconds as Seconds
 import qualified Podcast.Type.Title as Title
 
 data Episode = Episode
-  { date :: Date.Date
+  { article :: Article.Article
+  , date :: Date.Date
   , description :: Description.Description
   , duration :: Seconds.Seconds
   , guid :: Guid.Guid
@@ -22,5 +23,4 @@ data Episode = Episode
   , number :: Number.Number
   , size :: Bytes.Bytes
   , title :: Title.Title
-  , article :: Article.Article
   } deriving (Eq, Ord, Show)

--- a/source/library/Podcast/Type/Media.hs
+++ b/source/library/Podcast/Type/Media.hs
@@ -1,0 +1,18 @@
+module Podcast.Type.Media
+  ( Media
+  , fromString
+  , toString
+  )
+where
+
+import qualified Podcast.Type.Url as Url
+
+newtype Media
+  = Media Url.Url
+  deriving (Eq, Ord, Show)
+
+fromString :: String -> Either String Media
+fromString string = fmap Media (Url.fromString string)
+
+toString :: Media -> String
+toString (Media url) = Url.toString url

--- a/source/library/Podcast/Xml/Render.hs
+++ b/source/library/Podcast/Xml/Render.hs
@@ -32,11 +32,7 @@ attributes attributes_ =
 
 attribute :: Attribute.Attribute -> String
 attribute attribute_ = concat
-  [ Attribute.name attribute_
-  , "='"
-  , text (Attribute.value attribute_)
-  , "'"
-  ]
+  [Attribute.name attribute_, "='", text (Attribute.value attribute_), "'"]
 
 nodes :: [Element.Node] -> String
 nodes = concatMap node


### PR DESCRIPTION
This fixes #4.

Rather than making the show notes (also know as the episode description) full-blown HTML, I decided to leave them as plain text and extract the article link as a separate field. Maybe I'll come to regret that if we ever do a podcast for anything other than exactly one article. But for now it works well. 

I'm a little hesitant to see what happens with the descriptions in podcast players. There's no way for me as the podcast author to signal that the descriptions are actually HTML. It would make me feel better if I could say something like `<description type='html'>`. The spec links to these examples, which show escaped HTML in `<description>` fields: http://www.rssboard.org/rss-encoding-examples